### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.0](https://github.com/khorolets/near-ledger-rs/compare/v0.5.0...v0.6.0) - 2024-06-10
+
+### Other
+- added release-plz workflow to main and added fmt and clippy check ([#10](https://github.com/khorolets/near-ledger-rs/pull/10))
+- [**breaking**] updated deps to the newer version ([#9](https://github.com/khorolets/near-ledger-rs/pull/9))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION
## 🤖 New release
* `near-ledger`: 0.5.0 -> 0.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/khorolets/near-ledger-rs/compare/v0.5.0...v0.6.0) - 2024-06-10

### Other
- added release-plz workflow to main and added fmt and clippy check ([#10](https://github.com/khorolets/near-ledger-rs/pull/10))
- [**breaking**] updated deps to the newer version ([#9](https://github.com/khorolets/near-ledger-rs/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).