### PR TITLE
chore: Updaded near-* to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,11 @@ ledger-apdu = "0.11.0"
 slip10 = "0.4.3"
 log = "0.4.20"
 hex = "0.4.3"
-near-primitives-core = "0.22.0"
-near-primitives = "0.22.0"
+near-primitives-core = ">0.22,<0.24"
+near-primitives = ">0.22,<0.24"
 
 [dev-dependencies]
 env_logger = "0.11.0"
-near-crypto = "0.22.0"
-near-primitives = "0.22.0"
+near-crypto = ">0.22,<0.24"
+near-primitives = ">0.22,<0.24"
 near-account-id = { version = "1.0.0", features = ["internal_unstable"] }


### PR DESCRIPTION
It's not a breaking change as we support the old version as well.