### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/khorolets/near-ledger-rs/compare/v0.6.1...v0.7.0) - 2024-06-21
+
+### Other
+- [**breaking**] replace `ed25519-dalek 1.0.1` -> `ed25519-dalek 2.1.1`  ([#14](https://github.com/khorolets/near-ledger-rs/pull/14))
+
 ## [0.6.1](https://github.com/khorolets/near-ledger-rs/compare/v0.6.0...v0.6.1) - 2024-06-19
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION
## 🤖 New release
* `near-ledger`: 0.6.1 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/khorolets/near-ledger-rs/compare/v0.6.1...v0.7.0) - 2024-06-21

### Other
- [**breaking**] replace `ed25519-dalek 1.0.1` -> `ed25519-dalek 2.1.1`  ([#14](https://github.com/khorolets/near-ledger-rs/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).