### PR TITLE
chore: remove default features from `ed25519-dalek`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,11 +88,11 @@ name = "sign_nep_366_delegate_action"
 path = "examples/sign_nep_366_delegate_action.rs"
 
 [dependencies]
-ed25519-dalek = { version = "2" }
+ed25519-dalek = { version = "2", default-features = false }
 ledger-transport = "0.11.0"
 ledger-transport-hid = "0.11.0"
 ledger-apdu = "0.11.0"
-slipped10 = "0.4.5"
+slipped10 = { version = "0.4.6", git = "https://github.com/dj8yfo/slipped10.git", branch = "no_default_features"}
 log = "0.4.20"
 hex = "0.4.3"
 near-primitives-core = ">0.22,<0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ ed25519-dalek = { version = "2", default-features = false }
 ledger-transport = "0.11.0"
 ledger-transport-hid = "0.11.0"
 ledger-apdu = "0.11.0"
-slipped10 = { version = "0.4.6", git = "https://github.com/dj8yfo/slipped10.git", branch = "no_default_features"}
+slipped10 = { version = "0.4.6" }
 log = "0.4.20"
 hex = "0.4.3"
 near-primitives-core = ">0.22,<0.24"


### PR DESCRIPTION
go from

```bash
ed25519-dalek v2.1.1
├── ed25519-dalek feature "alloc"
│   └── ed25519-dalek feature "std"
│       └── ed25519-dalek feature "default"
│           ├── near-ledger v0.7.0 
│           │   └── near-ledger feature "default" 
│           └── slipped10 v0.4.5
│               └── slipped10 feature "default"
│                   └── near-ledger v0.7.0 
├── ed25519-dalek feature "default" 
├── ed25519-dalek feature "fast"
│   └── ed25519-dalek feature "default" 
├── ed25519-dalek feature "hazmat"
│   └── near-crypto v0.23.0
│       └── near-crypto feature "default"
│           └── near-primitives v0.23.0
│               └── near-primitives feature "default"
│                   └── near-ledger v0.7.0 
│                   [dev-dependencies]
│                   └── near-ledger v0.7.0 
│           [dev-dependencies]
│           └── near-ledger v0.7.0 
├── ed25519-dalek feature "rand_core"
│   └── near-crypto v0.23.0 
├── ed25519-dalek feature "std" 
└── ed25519-dalek feature "zeroize"
    ├── ed25519-dalek feature "alloc" 
    └── ed25519-dalek feature "default" 
```
to

```bash
ed25519-dalek v2.1.1
├── near-ledger v0.7.0 
│   └── near-ledger feature "default" 
└── slipped10 v0.4.6 
    └── slipped10 feature "default"
        └── near-ledger v0.7.0 
├── ed25519-dalek feature "hazmat"
│   └── near-crypto v0.23.0
│       └── near-crypto feature "default"
│           └── near-primitives v0.23.0
│               └── near-primitives feature "default"
│                   └── near-ledger v0.7.0 
│                   [dev-dependencies]
│                   └── near-ledger v0.7.0 
│           [dev-dependencies]
│           └── near-ledger v0.7.0 
└── ed25519-dalek feature "rand_core"
    └── near-crypto v0.23.0 (*)
```

