### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/khorolets/near-ledger-rs/compare/v0.7.0...v0.7.1) - 2024-06-24
+
+### Other
+- Slimmed down the dependencies by disabling default features on `ed25519-dalek` ([#16](https://github.com/khorolets/near-ledger-rs/pull/16))
+
 ## [0.7.0](https://github.com/khorolets/near-ledger-rs/compare/v0.6.1...v0.7.0) - 2024-06-21
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION
## 🤖 New release
* `near-ledger`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.1](https://github.com/khorolets/near-ledger-rs/compare/v0.7.0...v0.7.1) - 2024-06-24

### Other
- Slimmed down the dependencies by disabling default features on `ed25519-dalek` ([#16](https://github.com/khorolets/near-ledger-rs/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).