### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/khorolets/near-ledger-rs/compare/v0.7.1...v0.7.2) - 2024-08-08
+
+### Other
+- updated near-* crates to allow 0.24.0 in addition to all the previously supported versions ([#18](https://github.com/khorolets/near-ledger-rs/pull/18))
+
 ## [0.7.1](https://github.com/khorolets/near-ledger-rs/compare/v0.7.0...v0.7.1) - 2024-06-24
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION
## 🤖 New release
* `near-ledger`: 0.7.1 -> 0.7.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.2](https://github.com/khorolets/near-ledger-rs/compare/v0.7.1...v0.7.2) - 2024-08-08

### Other
- updated near-* crates to allow 0.24.0 in addition to all the previously supported versions ([#18](https://github.com/khorolets/near-ledger-rs/pull/18))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).