### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/khorolets/near-ledger-rs/compare/v0.8.0...v0.8.1) - 2024-08-23
+
+### Added
+- Added a function to open near app on the connected Ledger device ([#23](https://github.com/khorolets/near-ledger-rs/pull/23))
+
 ## [0.8.0](https://github.com/khorolets/near-ledger-rs/compare/v0.7.2...v0.8.0) - 2024-08-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION
## 🤖 New release
* `near-ledger`: 0.8.0 -> 0.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/khorolets/near-ledger-rs/compare/v0.8.0...v0.8.1) - 2024-08-23

### Added
- Added a function to open near app on the connected Ledger device ([#23](https://github.com/khorolets/near-ledger-rs/pull/23))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).