### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/khorolets/near-ledger-rs/compare/v0.8.1...v0.9.0) - 2025-02-07
+
+### Other
+
+- [**breaking**] fixed typo (#25)
+
 ## [0.8.1](https://github.com/khorolets/near-ledger-rs/compare/v0.8.0...v0.8.1) - 2024-08-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION



## 🤖 New release

* `near-ledger`: 0.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/khorolets/near-ledger-rs/compare/v0.8.1...v0.9.0) - 2025-02-07

### Other

- [**breaking**] fixed typo (#25)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).