### PR TITLE
feat: BLE suport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,20 @@ path = "examples/sign_nep_366_delegate_action.rs"
 name = "sign_nep_366_delegate_action_simple"
 path = "examples/sign_nep_366_delegate_action_simple.rs"
 
+[[example]]
+name = "get_version_ble"
+path = "examples/get_version_ble.rs"
+required-features = ["ble"]
+
+[[example]]
+name = "get_public_key_ble"
+path = "examples/get_public_key_ble.rs"
+required-features = ["ble"]
+
+[features]
+default = []
+ble = ["btleplug", "tokio", "futures", "byteorder", "uuid"]
+
 [dependencies]
 ed25519-dalek = { version = "2", default-features = false }
 ledger-transport = "0.11.0"
@@ -116,6 +130,11 @@ slipped10 = { version = "0.4.6" }
 log = "0.4.20"
 hex = "0.4.3"
 borsh = "1.5"
+btleplug = { version = "0.11", optional = true }
+tokio = { version = "1", features = ["macros", "time"], optional = true }
+futures = { version = "0.3", optional = true }
+byteorder = { version = "1.5", optional = true }
+uuid = { version = "1", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11.0"
@@ -124,3 +143,4 @@ near-primitives = ">0.22,<0.31"
 near-primitives-core = ">0.22,<0.31"
 near-account-id = { version = "1.0.0", features = ["internal_unstable"] }
 clap = { version = "4.5.39", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/get_public_key_ble.rs
+++ b/examples/get_public_key_ble.rs
@@ -1,0 +1,26 @@
+use std::str::FromStr;
+
+use near_ledger::{get_public_key_ble, open_near_application_ble, NEARLedgerError, TransportBle};
+use slipped10::BIP32Path;
+
+#[path = "common/lib.rs"]
+mod common;
+
+#[tokio::main]
+async fn main() -> Result<(), NEARLedgerError> {
+    env_logger::builder().init();
+
+    log::info!("Scanning for Ledger devices via BLE...");
+    let transport = TransportBle::new()
+        .await
+        .map_err(|e| NEARLedgerError::BleError(format!("{}", e)))?;
+    log::info!("Connected to Ledger via BLE");
+
+    open_near_application_ble(&transport).await?;
+    let hd_path = BIP32Path::from_str("44'/397'/0'/0'/1'").unwrap();
+    let public_key = get_public_key_ble(&transport, hd_path).await?;
+
+    common::display_pub_key(public_key);
+
+    Ok(())
+}

--- a/examples/get_version_ble.rs
+++ b/examples/get_version_ble.rs
@@ -1,0 +1,18 @@
+use near_ledger::{get_version_ble, open_near_application_ble, NEARLedgerError, TransportBle};
+
+#[tokio::main]
+async fn main() -> Result<(), NEARLedgerError> {
+    env_logger::builder().init();
+
+    log::info!("Scanning for Ledger devices via BLE...");
+    let transport = TransportBle::new()
+        .await
+        .map_err(|e| NEARLedgerError::BleError(format!("{}", e)))?;
+    log::info!("Connected to Ledger via BLE");
+
+    open_near_application_ble(&transport).await?;
+    let version = get_version_ble(&transport).await?;
+    log::info!("NEAR app version: {:#?}", version);
+
+    Ok(())
+}

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,0 +1,555 @@
+//! BLE (Bluetooth Low Energy) transport for communicating with Ledger devices.
+//!
+//! This module provides [`TransportBle`], which connects to a BLE-capable Ledger device
+//! (Nano X, Stax, Flex, or Nano Gen5) and exchanges APDU commands using the Ledger BLE
+//! framing protocol.
+//!
+//! # BLE Framing Protocol
+//!
+//! Ledger BLE uses a packet-based protocol on top of GATT characteristics:
+//! - **MTU negotiation**: Command tag `0x08`, retrieves the maximum payload per packet.
+//! - **APDU exchange**: Command tag `0x05`, sends an APDU and reads the response.
+//! - **Initial packet**: `[tag, seq_hi, seq_lo, len_hi, len_lo, ...payload]`
+//! - **Subsequent packets**: `[tag, seq_hi, seq_lo, ...payload]`
+
+use btleplug::api::{
+    Central, CharPropFlags, Characteristic, Manager as _, Peripheral as _, ScanFilter,
+    ValueNotification, WriteType,
+};
+use btleplug::platform::{Manager, Peripheral};
+use byteorder::{BigEndian, WriteBytesExt};
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use ledger_apdu::APDUAnswer;
+use ledger_transport::APDUCommand;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::fmt;
+use std::ops::Deref;
+use std::time::Duration;
+
+use crate::NEARLedgerError;
+
+// Ledger BLE service UUIDs
+// https://developers.ledger.com/docs/device-interaction/references/identifiers
+
+const NANO_X_SERVICE_UUID: Uuid = Uuid::from_fields(
+    0x13d63400,
+    0x2c97,
+    0x0004,
+    &[0x00, 0x00, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72],
+);
+
+const STAX_SERVICE_UUID: Uuid = Uuid::from_fields(
+    0x13d63400,
+    0x2c97,
+    0x6004,
+    &[0x00, 0x00, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72],
+);
+
+const FLEX_SERVICE_UUID: Uuid = Uuid::from_fields(
+    0x13d63400,
+    0x2c97,
+    0x3004,
+    &[0x00, 0x00, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72],
+);
+
+const NANO_GEN5_SERVICE_UUID: Uuid = Uuid::from_fields(
+    0x13d63400,
+    0x2c97,
+    0x8004,
+    &[0x00, 0x00, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72],
+);
+
+/// Nano Gen5 bootloader / early OS
+const NANO_GEN5_BOOTLOADER_SERVICE_UUID: Uuid = Uuid::from_fields(
+    0x13d63400,
+    0x2c97,
+    0x9004,
+    &[0x00, 0x00, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72],
+);
+
+const LEDGER_SERVICE_UUIDS: &[Uuid] = &[
+    NANO_X_SERVICE_UUID,
+    STAX_SERVICE_UUID,
+    FLEX_SERVICE_UUID,
+    NANO_GEN5_SERVICE_UUID,
+    NANO_GEN5_BOOTLOADER_SERVICE_UUID,
+];
+
+const MTU_COMMAND_TAG: u8 = 0x08;
+const APDU_COMMAND_TAG: u8 = 0x05;
+const BLE_SCAN_DURATION_SECS: u64 = 5;
+const DEFAULT_MTU_SIZE: usize = 20;
+const BLE_RESPONSE_TIMEOUT_SECS: u64 = 30;
+
+fn is_ledger_service_uuid(uuid: &Uuid) -> bool {
+    LEDGER_SERVICE_UUIDS.contains(uuid)
+}
+
+/// Derive the notify characteristic UUID from a Ledger service UUID.
+///
+/// Ledger characteristic UUIDs follow a pattern: service has `0000` in
+/// d4 bytes 0-1, notify has `0001`, write has `0002`.
+fn notify_uuid_for_service(service: &Uuid) -> Uuid {
+    let (d1, d2, d3, d4) = service.as_fields();
+    let mut d4_new = *d4;
+    d4_new[1] = 0x01;
+    Uuid::from_fields(d1, d2, d3, &d4_new)
+}
+
+fn write_uuid_for_service(service: &Uuid) -> Uuid {
+    let (d1, d2, d3, d4) = service.as_fields();
+    let mut d4_new = *d4;
+    d4_new[1] = 0x02;
+    Uuid::from_fields(d1, d2, d3, &d4_new)
+}
+
+/// BLE-specific errors
+#[derive(Debug)]
+pub enum BleError {
+    Ble(btleplug::Error),
+    DeviceNotFound,
+    InvalidPacket,
+    Comm(&'static str),
+    Timeout,
+}
+
+impl fmt::Display for BleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BleError::Ble(err) => write!(f, "BLE error: {}", err),
+            BleError::DeviceNotFound => write!(f, "No Ledger device found via BLE"),
+            BleError::InvalidPacket => write!(f, "Invalid BLE packet received from Ledger"),
+            BleError::Comm(msg) => write!(f, "BLE communication error: {}", msg),
+            BleError::Timeout => write!(f, "Timeout waiting for Ledger BLE response"),
+        }
+    }
+}
+
+impl From<btleplug::Error> for BleError {
+    fn from(err: btleplug::Error) -> Self {
+        BleError::Ble(err)
+    }
+}
+
+impl From<BleError> for NEARLedgerError {
+    fn from(err: BleError) -> Self {
+        NEARLedgerError::BleError(format!("{}", err))
+    }
+}
+
+/// `[tag, seq(2), data_len(2), ...payload]`
+#[derive(Debug)]
+struct InitialPacket {
+    command_tag: u8,
+    data_length: u16,
+    payload: Vec<u8>,
+}
+
+impl InitialPacket {
+    fn serialize(self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.payload.len() + 5);
+        buf.write_u8(self.command_tag).unwrap();
+        buf.write_u16::<BigEndian>(0).unwrap(); // sequence index
+        buf.write_u16::<BigEndian>(self.data_length).unwrap();
+        buf.extend(self.payload);
+        buf
+    }
+}
+
+impl TryFrom<Vec<u8>> for InitialPacket {
+    type Error = BleError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() < 5 {
+            return Err(BleError::InvalidPacket);
+        }
+        let payload = if value.len() == 5 {
+            Vec::new()
+        } else {
+            value[5..].to_vec()
+        };
+        Ok(InitialPacket {
+            command_tag: value[0],
+            data_length: u16::from_be_bytes([value[3], value[4]]),
+            payload,
+        })
+    }
+}
+
+/// `[tag, seq(2), ...payload]`
+#[derive(Debug)]
+struct SubsequentPacket {
+    command_tag: u8,
+    _packet_sequence_index: u16,
+    payload: Vec<u8>,
+}
+
+impl SubsequentPacket {
+    fn serialize(self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.payload.len() + 3);
+        buf.write_u8(self.command_tag).unwrap();
+        buf.write_u16::<BigEndian>(self._packet_sequence_index)
+            .unwrap();
+        buf.extend(self.payload);
+        buf
+    }
+}
+
+impl TryFrom<Vec<u8>> for SubsequentPacket {
+    type Error = BleError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() < 3 {
+            return Err(BleError::InvalidPacket);
+        }
+        let payload = if value.len() == 3 {
+            Vec::new()
+        } else {
+            value[3..].to_vec()
+        };
+        Ok(SubsequentPacket {
+            command_tag: value[0],
+            _packet_sequence_index: u16::from_be_bytes([value[1], value[2]]),
+            payload,
+        })
+    }
+}
+
+/// BLE transport for communicating with a Ledger device.
+///
+/// # Example
+///
+/// ```no_run
+/// use near_ledger::{TransportBle, BleError};
+///
+/// # async fn example() -> Result<(), BleError> {
+/// let transport = TransportBle::new().await?;
+/// // Use with BLE API functions...
+/// # Ok(())
+/// # }
+/// ```
+pub struct TransportBle {
+    device: Peripheral,
+    write_characteristic: Characteristic,
+    notifications: Mutex<BoxStream<'static, ValueNotification>>,
+    mtu_size: Mutex<Option<usize>>,
+}
+
+impl fmt::Debug for TransportBle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransportBle")
+            .field("write_characteristic", &self.write_characteristic)
+            .finish()
+    }
+}
+
+impl TransportBle {
+    async fn is_ledger(peripheral: &Peripheral) -> bool {
+        if let Ok(Some(props)) = peripheral.properties().await {
+            if let Some(ref name) = props.local_name {
+                if name.starts_with("Nano X")
+                    || name.starts_with("Nano S Plus")
+                    || name.starts_with("Stax")
+                    || name.starts_with("Flex")
+                    || name.starts_with("Ledger")
+                {
+                    return true;
+                }
+            }
+            for svc in &props.services {
+                if is_ledger_service_uuid(svc) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Scan for available Ledger devices via BLE.
+    pub async fn list_ledgers() -> Result<Vec<Peripheral>, BleError> {
+        let manager = Manager::new().await?;
+        let adapter_list = manager.adapters().await?;
+
+        let mut ledgers = Vec::new();
+
+        for adapter in adapter_list.iter() {
+            adapter.start_scan(ScanFilter::default()).await?;
+            tokio::time::sleep(Duration::from_secs(BLE_SCAN_DURATION_SECS)).await;
+            adapter.stop_scan().await?;
+
+            let peripherals = adapter.peripherals().await?;
+            for peripheral in peripherals {
+                if Self::is_ledger(&peripheral).await {
+                    ledgers.push(peripheral);
+                }
+            }
+        }
+
+        Ok(ledgers)
+    }
+
+    /// Scan for and connect to the first available Ledger device.
+    pub async fn new() -> Result<Self, BleError> {
+        let ledgers = Self::list_ledgers().await?;
+        let ledger = ledgers.into_iter().next().ok_or(BleError::DeviceNotFound)?;
+        Self::connect(ledger).await
+    }
+
+    /// Connect to a specific BLE peripheral as a Ledger device.
+    ///
+    /// The peripheral should be one returned by [`list_ledgers`](Self::list_ledgers).
+    pub async fn connect(peripheral: Peripheral) -> Result<Self, BleError> {
+        if !peripheral.is_connected().await? {
+            peripheral.connect().await?;
+        }
+        peripheral.discover_services().await?;
+
+        let characteristics = peripheral.characteristics();
+
+        let service_uuid = characteristics
+            .iter()
+            .map(|c| c.service_uuid)
+            .find(is_ledger_service_uuid);
+
+        let (write_characteristic, notify_characteristic) = if let Some(svc) = service_uuid {
+            let expected_write = write_uuid_for_service(&svc);
+            let expected_notify = notify_uuid_for_service(&svc);
+
+            let write_char = characteristics
+                .iter()
+                .find(|c| c.uuid == expected_write)
+                .cloned()
+                .ok_or(BleError::Comm(
+                    "Ledger WRITE characteristic not found for service",
+                ))?;
+
+            let notify_char = characteristics
+                .iter()
+                .find(|c| c.uuid == expected_notify)
+                .cloned()
+                .ok_or(BleError::Comm(
+                    "Ledger NOTIFY characteristic not found for service",
+                ))?;
+
+            (write_char, notify_char)
+        } else {
+            // Fallback for unknown future devices: match by GATT property flags
+            let write_char = characteristics
+                .iter()
+                .find(|c| c.properties.contains(CharPropFlags::WRITE))
+                .cloned()
+                .ok_or(BleError::Comm(
+                    "No WRITE characteristic found on Ledger device",
+                ))?;
+
+            let notify_char = characteristics
+                .iter()
+                .find(|c| c.properties.contains(CharPropFlags::NOTIFY))
+                .cloned()
+                .ok_or(BleError::Comm(
+                    "No NOTIFY characteristic found on Ledger device",
+                ))?;
+
+            (write_char, notify_char)
+        };
+
+        peripheral.subscribe(&notify_characteristic).await?;
+        let notifications = peripheral.notifications().await?;
+
+        let transport = TransportBle {
+            device: peripheral,
+            write_characteristic,
+            notifications: Mutex::new(notifications),
+            mtu_size: Mutex::new(None),
+        };
+
+        transport.infer_mtu().await?;
+
+        Ok(transport)
+    }
+
+    async fn write(&self, data: &[u8]) -> Result<(), BleError> {
+        log::info!("BLE => {}", hex::encode(data));
+        self.device
+            .write(&self.write_characteristic, data, WriteType::WithResponse)
+            .await?;
+        Ok(())
+    }
+
+    async fn next_notification(&self) -> Result<Vec<u8>, BleError> {
+        let timeout = Duration::from_secs(BLE_RESPONSE_TIMEOUT_SECS);
+        let mut stream = self.notifications.lock().await;
+        match tokio::time::timeout(timeout, stream.next()).await {
+            Ok(Some(notif)) => {
+                log::info!("BLE <= {}", hex::encode(&notif.value));
+                Ok(notif.value)
+            }
+            Ok(None) => Err(BleError::Comm("BLE notification stream ended unexpectedly")),
+            Err(_) => Err(BleError::Timeout),
+        }
+    }
+
+    /// Send a framed request, splitting into BLE packets as needed.
+    async fn send_framed(
+        &self,
+        command_tag: u8,
+        payload: &[u8],
+        mtu_size: usize,
+    ) -> Result<(), BleError> {
+        let first_chunk_data_size = mtu_size.saturating_sub(5);
+        let subsequent_chunk_data_size = mtu_size.saturating_sub(3);
+
+        if payload.len() > u16::MAX as usize {
+            return Err(BleError::Comm(
+                "Payload too large for BLE framing (>65535 bytes)",
+            ));
+        }
+
+        let first_data_end = std::cmp::min(first_chunk_data_size, payload.len());
+        let initial_packet = InitialPacket {
+            command_tag,
+            data_length: payload.len() as u16,
+            payload: payload[..first_data_end].to_vec(),
+        };
+        self.write(&initial_packet.serialize()).await?;
+
+        let mut offset = first_data_end;
+        let mut seq_index: u16 = 1;
+        while offset < payload.len() {
+            let end = std::cmp::min(offset + subsequent_chunk_data_size, payload.len());
+            let packet = SubsequentPacket {
+                command_tag,
+                _packet_sequence_index: seq_index,
+                payload: payload[offset..end].to_vec(),
+            };
+            self.write(&packet.serialize()).await?;
+            offset = end;
+            seq_index += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Receive a framed response, reassembling from BLE packets.
+    async fn recv_framed(&self, command_tag: u8) -> Result<Vec<u8>, BleError> {
+        let raw = loop {
+            let data = self.next_notification().await?;
+            if data.is_empty() {
+                return Err(BleError::InvalidPacket);
+            }
+            if data[0] == command_tag {
+                break data;
+            }
+            log::info!("BLE: skipping notification with tag 0x{:02x}", data[0]);
+        };
+
+        let initial_packet: InitialPacket = raw.try_into()?;
+        log::info!(
+            "BLE recv initial: tag=0x{:02x} data_length={} payload_len={}",
+            initial_packet.command_tag,
+            initial_packet.data_length,
+            initial_packet.payload.len()
+        );
+
+        let total_length = initial_packet.data_length as usize;
+        let mut buffer = initial_packet.payload;
+
+        while buffer.len() < total_length {
+            let raw = self.next_notification().await?;
+            let packet: SubsequentPacket = raw.try_into()?;
+            if packet.command_tag != command_tag {
+                log::info!(
+                    "BLE: skipping subsequent packet with tag 0x{:02x}",
+                    packet.command_tag
+                );
+                continue;
+            }
+            log::info!(
+                "BLE recv subsequent: seq={} payload_len={}",
+                packet._packet_sequence_index,
+                packet.payload.len()
+            );
+            buffer.extend(packet.payload);
+        }
+
+        buffer.truncate(total_length);
+        Ok(buffer)
+    }
+
+    /// Negotiate the MTU with the Ledger device.
+    ///
+    /// The MTU response does NOT follow the standard framing. Per the official
+    /// Ledger JS reference (`TransportWebBLE.inferMTU`), byte at index 5 of the
+    /// raw notification is the mtu_size value used by `send_framed`.
+    async fn infer_mtu(&self) -> Result<usize, BleError> {
+        self.write(&[MTU_COMMAND_TAG, 0x00, 0x00, 0x00, 0x00])
+            .await?;
+
+        // Read raw response (not using recv_framed — non-standard format)
+        let raw = loop {
+            let data = self.next_notification().await?;
+            if !data.is_empty() && data[0] == MTU_COMMAND_TAG {
+                break data;
+            }
+            log::info!(
+                "BLE: skipping non-MTU notification with tag 0x{:02x}",
+                data.first().copied().unwrap_or(0)
+            );
+        };
+
+        if raw.len() < 6 {
+            log::warn!(
+                "BLE: MTU response too short ({} bytes), using default {}",
+                raw.len(),
+                DEFAULT_MTU_SIZE
+            );
+            let mut mtu = self.mtu_size.lock().await;
+            *mtu = Some(DEFAULT_MTU_SIZE);
+            return Ok(DEFAULT_MTU_SIZE);
+        }
+
+        let mtu_size = raw[5] as usize;
+        // Initial packet header is 5 bytes, so mtu_size must be > 5 to carry any data.
+        // Fall back to default if the device returns something unusably small.
+        let mtu_size = if mtu_size > 5 {
+            mtu_size
+        } else {
+            log::warn!(
+                "BLE: negotiated mtu_size={} too small, using default {}",
+                mtu_size,
+                DEFAULT_MTU_SIZE
+            );
+            DEFAULT_MTU_SIZE
+        };
+        log::info!("BLE: mtu_size={}", mtu_size);
+
+        let mut mtu = self.mtu_size.lock().await;
+        *mtu = Some(mtu_size);
+        Ok(mtu_size)
+    }
+
+    async fn get_mtu_size(&self) -> usize {
+        let mtu = self.mtu_size.lock().await;
+        mtu.unwrap_or(DEFAULT_MTU_SIZE)
+    }
+
+    /// Exchange an APDU command with the Ledger device over BLE.
+    pub async fn exchange<I: Deref<Target = [u8]>>(
+        &self,
+        command: &APDUCommand<I>,
+    ) -> Result<APDUAnswer<Vec<u8>>, BleError> {
+        let apdu_data = command.serialize();
+        let mtu_size = self.get_mtu_size().await;
+
+        self.send_framed(APDU_COMMAND_TAG, &apdu_data, mtu_size)
+            .await?;
+
+        let answer = self.recv_framed(APDU_COMMAND_TAG).await?;
+        APDUAnswer::from_answer(answer).map_err(|_| BleError::Comm("Response was too short"))
+    }
+}

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -185,7 +185,7 @@ impl TryFrom<Vec<u8>> for InitialPacket {
 #[derive(Debug)]
 struct SubsequentPacket {
     command_tag: u8,
-    _packet_sequence_index: u16,
+    packet_sequence_index: u16,
     payload: Vec<u8>,
 }
 
@@ -193,7 +193,7 @@ impl SubsequentPacket {
     fn serialize(self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.payload.len() + 3);
         buf.write_u8(self.command_tag).unwrap();
-        buf.write_u16::<BigEndian>(self._packet_sequence_index)
+        buf.write_u16::<BigEndian>(self.packet_sequence_index)
             .unwrap();
         buf.extend(self.payload);
         buf
@@ -214,7 +214,7 @@ impl TryFrom<Vec<u8>> for SubsequentPacket {
         };
         Ok(SubsequentPacket {
             command_tag: value[0],
-            _packet_sequence_index: u16::from_be_bytes([value[1], value[2]]),
+            packet_sequence_index: u16::from_be_bytes([value[1], value[2]]),
             payload,
         })
     }
@@ -424,7 +424,7 @@ impl TransportBle {
             let end = std::cmp::min(offset + subsequent_chunk_data_size, payload.len());
             let packet = SubsequentPacket {
                 command_tag,
-                _packet_sequence_index: seq_index,
+                packet_sequence_index: seq_index,
                 payload: payload[offset..end].to_vec(),
             };
             self.write(&packet.serialize()).await?;
@@ -471,7 +471,7 @@ impl TransportBle {
             }
             log::info!(
                 "BLE recv subsequent: seq={} payload_len={}",
-                packet._packet_sequence_index,
+                packet.packet_sequence_index,
                 packet.payload.len()
             );
             buffer.extend(packet.payload);

--- a/src/ble_api.rs
+++ b/src/ble_api.rs
@@ -1,0 +1,375 @@
+//! Async BLE API functions mirroring the USB HID API.
+//!
+//! All functions take a [`TransportBle`] reference, which should be reused across calls.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use near_ledger::{TransportBle, get_version_ble};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let transport = TransportBle::new().await.map_err(|e| format!("{:?}", e))?;
+//! let version = get_version_ble(&transport).await.map_err(|e| format!("{:?}", e))?;
+//! println!("NEAR app version: {:?}", version);
+//! # Ok(())
+//! # }
+//! ```
+
+use ed25519_dalek::PUBLIC_KEY_LENGTH;
+use ledger_transport::APDUCommand;
+use std::time::Duration;
+use tokio::time::sleep;
+
+use crate::ble::TransportBle;
+use crate::{
+    hd_path_to_bytes, log_command, retcode_to_error_string, BorshSerializedDelegateAction,
+    BorshSerializedUnsignedTransaction, NEARLedgerAppVersion, NEARLedgerError, NEP413Payload,
+    SignatureBytes, CHUNK_SIZE, CLA, CLA_DASHBOARD, CLA_OPEN_APP, INS_GET_APP_NAME,
+    INS_GET_PUBLIC_KEY, INS_GET_VERSION, INS_GET_WALLET_ID, INS_OPEN_APP, INS_QUIT_APP,
+    INS_SIGN_NEP366_DELEGATE_ACTION, INS_SIGN_NEP413_MESSAGE, INS_SIGN_TRANSACTION, NETWORK_ID,
+    P1_GET_PUB_DISPLAY, P1_GET_PUB_SILENT, P1_SIGN_NORMAL, P1_SIGN_NORMAL_LAST_CHUNK,
+    RETURN_CODE_OK, RETURN_CODE_UNKNOWN_ERROR,
+};
+
+/// Get the version of the NEAR App installed on a BLE-connected Ledger device
+pub async fn get_version_ble(
+    transport: &TransportBle,
+) -> Result<NEARLedgerAppVersion, NEARLedgerError> {
+    let command = APDUCommand {
+        cla: CLA,
+        ins: INS_GET_VERSION,
+        p1: 0,
+        p2: 0,
+        data: vec![],
+    };
+
+    log::info!("APDU  in (BLE): {}", hex::encode(command.serialize()));
+
+    match transport.exchange(&command).await {
+        Ok(response) => {
+            log::info!(
+                "APDU out (BLE): {}\nAPDU ret code: {:x}",
+                hex::encode(response.apdu_data()),
+                response.retcode(),
+            );
+            if response.retcode() == RETURN_CODE_OK {
+                Ok(response.data().to_vec())
+            } else {
+                Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    response.retcode(),
+                )))
+            }
+        }
+        Err(err) => Err(NEARLedgerError::from(err)),
+    }
+}
+
+async fn running_app_name_ble(transport: &TransportBle) -> Result<String, NEARLedgerError> {
+    let command = APDUCommand {
+        cla: CLA_DASHBOARD,
+        ins: INS_GET_APP_NAME,
+        p1: 0,
+        p2: 0,
+        data: vec![],
+    };
+
+    log::info!("APDU  in (BLE): {}", hex::encode(command.serialize()));
+
+    match transport.exchange(&command).await {
+        Ok(response) => {
+            log::info!(
+                "APDU out (BLE): {}\nAPDU ret code: {:x}",
+                hex::encode(response.apdu_data()),
+                response.retcode(),
+            );
+            match response.retcode() {
+                RETURN_CODE_OK => {
+                    let data = response.data();
+                    if data.len() < 2 {
+                        return Err(NEARLedgerError::APDUExchangeError(
+                            "App name response too short".to_string(),
+                        ));
+                    }
+                    let app_name_len = data[1] as usize;
+                    if data.len() < 2 + app_name_len {
+                        return Err(NEARLedgerError::APDUExchangeError(
+                            "App name response truncated".to_string(),
+                        ));
+                    }
+                    let app_name = String::from_utf8_lossy(&data[2..2 + app_name_len]).to_string();
+                    Ok(app_name)
+                }
+                RETURN_CODE_UNKNOWN_ERROR => Err(NEARLedgerError::APDUExchangeError(
+                    "The ledger most likely is locked. Please unlock ledger or reconnect it"
+                        .to_string(),
+                )),
+                retcode => Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    retcode,
+                ))),
+            }
+        }
+        Err(err) => Err(NEARLedgerError::from(err)),
+    }
+}
+
+async fn quit_open_application_ble(transport: &TransportBle) -> Result<(), NEARLedgerError> {
+    let command = APDUCommand {
+        cla: CLA_DASHBOARD,
+        ins: INS_QUIT_APP,
+        p1: 0,
+        p2: 0,
+        data: vec![],
+    };
+
+    log::info!("APDU  in (BLE): {}", hex::encode(command.serialize()));
+
+    match transport.exchange(&command).await {
+        Ok(response) => {
+            log::info!(
+                "APDU out (BLE): {}\nAPDU ret code: {:x}",
+                hex::encode(response.apdu_data()),
+                response.retcode(),
+            );
+            match response.retcode() {
+                RETURN_CODE_OK => Ok(()),
+                retcode => Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    retcode,
+                ))),
+            }
+        }
+        Err(err) => Err(NEARLedgerError::from(err)),
+    }
+}
+
+/// Open the NEAR application on a BLE-connected Ledger device.
+/// No-op if NEAR app is already open.
+pub async fn open_near_application_ble(transport: &TransportBle) -> Result<(), NEARLedgerError> {
+    match running_app_name_ble(transport).await?.as_str() {
+        "NEAR" => return Ok(()),
+        "BOLOS" => {}
+        _ => {
+            quit_open_application_ble(transport).await?;
+            // Wait for the Ledger to close the app
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    let data = b"NEAR".to_vec();
+    let command: APDUCommand<Vec<u8>> = APDUCommand {
+        cla: CLA_OPEN_APP,
+        ins: INS_OPEN_APP,
+        p1: 0x00,
+        p2: 0x00,
+        data,
+    };
+
+    log::info!("APDU  in (BLE): {}", hex::encode(command.serialize()));
+
+    match transport.exchange(&command).await {
+        Ok(response) => {
+            log::info!("APDU ret code (BLE): {:x}", response.retcode());
+            match response.retcode() {
+                RETURN_CODE_OK => Ok(()),
+                retcode => Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    retcode,
+                ))),
+            }
+        }
+        Err(err) => Err(NEARLedgerError::from(err)),
+    }
+}
+
+/// Gets PublicKey from a BLE-connected Ledger on the given `hd_path`.
+/// The key will be displayed on the Ledger screen for user confirmation.
+pub async fn get_public_key_ble(
+    transport: &TransportBle,
+    hd_path: slipped10::BIP32Path,
+) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
+    get_public_key_with_display_flag_ble(transport, hd_path, true).await
+}
+
+/// Gets PublicKey from a BLE-connected Ledger, optionally displaying on the device screen
+pub async fn get_public_key_with_display_flag_ble(
+    transport: &TransportBle,
+    hd_path: slipped10::BIP32Path,
+    display_and_confirm: bool,
+) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
+    let hd_path_bytes = hd_path_to_bytes(&hd_path);
+
+    let p1 = if display_and_confirm {
+        P1_GET_PUB_DISPLAY
+    } else {
+        P1_GET_PUB_SILENT
+    };
+
+    let command = APDUCommand {
+        cla: CLA,
+        ins: INS_GET_PUBLIC_KEY,
+        p1,
+        p2: NETWORK_ID,
+        data: hd_path_bytes,
+    };
+    log::info!("APDU  in (BLE): {}", hex::encode(command.serialize()));
+
+    match transport.exchange(&command).await {
+        Ok(response) => handle_public_key_response_ble(response),
+        Err(err) => Err(NEARLedgerError::from(err)),
+    }
+}
+
+/// Gets the Wallet ID from a BLE-connected Ledger on the given `hd_path`
+pub async fn get_wallet_id_ble(
+    transport: &TransportBle,
+    hd_path: slipped10::BIP32Path,
+) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
+    let hd_path_bytes = hd_path_to_bytes(&hd_path);
+
+    let command = APDUCommand {
+        cla: CLA,
+        ins: INS_GET_WALLET_ID,
+        p1: 0,
+        p2: NETWORK_ID,
+        data: hd_path_bytes,
+    };
+    log::info!("APDU  in (BLE): {}", hex::encode(command.serialize()));
+
+    match transport.exchange(&command).await {
+        Ok(response) => handle_public_key_response_ble(response),
+        Err(err) => Err(NEARLedgerError::from(err)),
+    }
+}
+
+fn handle_public_key_response_ble(
+    response: ledger_apdu::APDUAnswer<Vec<u8>>,
+) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
+    log::info!(
+        "APDU out (BLE): {}\nAPDU ret code: {:x}",
+        hex::encode(response.apdu_data()),
+        response.retcode(),
+    );
+    if response.retcode() == RETURN_CODE_OK {
+        let data = response.data();
+        if data.len() != PUBLIC_KEY_LENGTH {
+            return Err(NEARLedgerError::APDUExchangeError(format!(
+                "`{}` response obtained of invalid length {} != {} (expected)",
+                hex::encode(data),
+                data.len(),
+                PUBLIC_KEY_LENGTH
+            )));
+        }
+        let mut bytes: [u8; PUBLIC_KEY_LENGTH] = [0u8; PUBLIC_KEY_LENGTH];
+        bytes.copy_from_slice(data);
+
+        let key = ed25519_dalek::VerifyingKey::from_bytes(&bytes).map_err(|err| {
+            NEARLedgerError::APDUExchangeError(format!(
+                "problem constructing `ed25519_dalek::VerifyingKey` from \
+                received byte array: {}, err: {:?}",
+                hex::encode(data),
+                err
+            ))
+        })?;
+        Ok(key)
+    } else {
+        Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+            response.retcode(),
+        )))
+    }
+}
+
+/// Sign a borsh-serialized transaction on a BLE-connected Ledger device
+pub async fn sign_transaction_ble(
+    transport: &TransportBle,
+    unsigned_tx: BorshSerializedUnsignedTransaction<'_>,
+    seed_phrase_hd_path: slipped10::BIP32Path,
+) -> Result<SignatureBytes, NEARLedgerError> {
+    send_payload_apdus_ble(
+        transport,
+        unsigned_tx,
+        seed_phrase_hd_path,
+        INS_SIGN_TRANSACTION,
+    )
+    .await
+}
+
+/// Sign an NEP-413 off-chain message on a BLE-connected Ledger device
+pub async fn sign_message_nep413_ble(
+    transport: &TransportBle,
+    payload: &NEP413Payload,
+    seed_phrase_hd_path: slipped10::BIP32Path,
+) -> Result<SignatureBytes, NEARLedgerError> {
+    send_payload_apdus_ble(
+        transport,
+        &borsh::to_vec(payload).unwrap(),
+        seed_phrase_hd_path,
+        INS_SIGN_NEP413_MESSAGE,
+    )
+    .await
+}
+
+/// Sign an NEP-366 delegate action on a BLE-connected Ledger device
+pub async fn sign_message_nep366_delegate_action_ble(
+    transport: &TransportBle,
+    payload: BorshSerializedDelegateAction<'_>,
+    seed_phrase_hd_path: slipped10::BIP32Path,
+) -> Result<SignatureBytes, NEARLedgerError> {
+    send_payload_apdus_ble(
+        transport,
+        payload,
+        seed_phrase_hd_path,
+        INS_SIGN_NEP366_DELEGATE_ACTION,
+    )
+    .await
+}
+
+async fn send_payload_apdus_ble(
+    transport: &TransportBle,
+    payload: &[u8],
+    seed_phrase_hd_path: slipped10::BIP32Path,
+    ins: u8,
+) -> Result<SignatureBytes, NEARLedgerError> {
+    let hd_path_bytes = hd_path_to_bytes(&seed_phrase_hd_path);
+
+    let mut data: Vec<u8> = vec![];
+    data.extend(hd_path_bytes);
+    data.extend_from_slice(payload);
+    let chunks = data.chunks(CHUNK_SIZE);
+    let chunks_count = chunks.len();
+
+    for (i, chunk) in chunks.enumerate() {
+        let is_last_chunk = chunks_count == i + 1;
+        let command = APDUCommand {
+            cla: CLA,
+            ins,
+            p1: if is_last_chunk {
+                P1_SIGN_NORMAL_LAST_CHUNK
+            } else {
+                P1_SIGN_NORMAL
+            },
+            p2: NETWORK_ID,
+            data: chunk.to_vec(),
+        };
+        log_command(i, is_last_chunk, &command);
+        match transport.exchange(&command).await {
+            Ok(response) => {
+                log::info!(
+                    "APDU out (BLE): {}\nAPDU ret code: {:x}",
+                    hex::encode(response.apdu_data()),
+                    response.retcode(),
+                );
+                if response.retcode() == RETURN_CODE_OK {
+                    if is_last_chunk {
+                        return Ok(response.data().to_vec());
+                    }
+                } else {
+                    return Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                        response.retcode(),
+                    )));
+                }
+            }
+            Err(err) => return Err(NEARLedgerError::from(err)),
+        };
+    }
+    Err(NEARLedgerError::APDUExchangeError(
+        "Unable to process request".to_owned(),
+    ))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,35 +16,86 @@ use ledger_transport_hid::{
 
 pub mod print_apdus;
 
-const CLA: u8 = 0x80; // Instruction class
-const INS_GET_PUBLIC_KEY: u8 = 4; // Instruction code to get public key
-const INS_GET_WALLET_ID: u8 = 0x05; // Get Wallet ID
-const INS_GET_VERSION: u8 = 6; // Instruction code to get app version from the Ledger
-const INS_SIGN_TRANSACTION: u8 = 2; // Instruction code to sign a transaction on the Ledger
-const INS_SIGN_NEP413_MESSAGE: u8 = 7; // Instruction code to sign a nep-413 message with Ledger
-const INS_SIGN_NEP366_DELEGATE_ACTION: u8 = 8; // Instruction code to sign a nep-413 message with Ledger
-const NETWORK_ID: u8 = b'W'; // Instruction parameter 2
-const RETURN_CODE_OK: u16 = 0x9000; // APDUAnswer.retcode which means success from Ledger
-const CHUNK_SIZE: usize = 250; // Chunk size to be sent to Ledger
+#[cfg(feature = "ble")]
+mod ble;
+#[cfg(feature = "ble")]
+mod ble_api;
 
-const RETURN_CODE_APP_MISSING: u16 = 0x6807;
-const RETURN_CODE_ERROR_INPUT: u16 = 0x670A;
-const RETURN_CODE_UNKNOWN_ERROR: u16 = 0x5515;
+#[cfg(feature = "ble")]
+pub use ble::{BleError, TransportBle};
+
+#[cfg(feature = "ble")]
+pub use ble_api::{
+    get_public_key_ble, get_public_key_with_display_flag_ble, get_version_ble, get_wallet_id_ble,
+    open_near_application_ble, sign_message_nep366_delegate_action_ble, sign_message_nep413_ble,
+    sign_transaction_ble,
+};
+
+pub(crate) const CLA: u8 = 0x80; // Instruction class
+pub(crate) const INS_GET_PUBLIC_KEY: u8 = 4; // Instruction code to get public key
+pub(crate) const INS_GET_WALLET_ID: u8 = 0x05; // Get Wallet ID
+pub(crate) const INS_GET_VERSION: u8 = 6; // Instruction code to get app version from the Ledger
+pub(crate) const INS_SIGN_TRANSACTION: u8 = 2; // Instruction code to sign a transaction on the Ledger
+pub(crate) const INS_SIGN_NEP413_MESSAGE: u8 = 7; // Instruction code to sign a nep-413 message with Ledger
+pub(crate) const INS_SIGN_NEP366_DELEGATE_ACTION: u8 = 8; // Instruction code to sign a nep-413 message with Ledger
+pub(crate) const NETWORK_ID: u8 = b'W'; // Instruction parameter 2
+pub(crate) const RETURN_CODE_OK: u16 = 0x9000; // APDUAnswer.retcode which means success from Ledger
+pub(crate) const CHUNK_SIZE: usize = 250; // Chunk size to be sent to Ledger
+
+// Dashboard APDU constants (BOLOS / device-level commands)
+pub(crate) const CLA_DASHBOARD: u8 = 0xB0;
+pub(crate) const INS_GET_APP_NAME: u8 = 0x01;
+pub(crate) const INS_QUIT_APP: u8 = 0xA7;
+pub(crate) const CLA_OPEN_APP: u8 = 0xE0;
+pub(crate) const INS_OPEN_APP: u8 = 0xD8;
+
+pub(crate) const RETURN_CODE_APP_MISSING: u16 = 0x6807;
+pub(crate) const RETURN_CODE_ERROR_INPUT: u16 = 0x670A;
+pub(crate) const RETURN_CODE_UNKNOWN_ERROR: u16 = 0x5515;
 
 /// This error code is returned when the user declines to open the app.
 /// But I couldn't find it in the any of the ledger documentation...
-const RETURN_CODE_DECLINE: u16 = 0x5501;
+pub(crate) const RETURN_CODE_DECLINE: u16 = 0x5501;
+
+/// ISO 7816 "CLA not supported" — typically means the NEAR app is not open
+pub(crate) const RETURN_CODE_CLA_NOT_SUPPORTED: u16 = 0x6E01;
+/// ISO 7816 "INS not supported"
+pub(crate) const RETURN_CODE_INS_NOT_SUPPORTED: u16 = 0x6D00;
+
+/// Map a Ledger APDU return code to a human-readable error string.
+pub(crate) fn retcode_to_error_string(retcode: u16) -> String {
+    match retcode {
+        RETURN_CODE_OK => "Success".to_string(),
+        RETURN_CODE_CLA_NOT_SUPPORTED => {
+            "NEAR app is not open on the Ledger device (CLA not supported, 0x6E01)".to_string()
+        }
+        RETURN_CODE_INS_NOT_SUPPORTED => {
+            "Instruction not supported by the Ledger app (INS not supported, 0x6D00)".to_string()
+        }
+        RETURN_CODE_APP_MISSING => {
+            "NEAR application is missing on the Ledger device (0x6807)".to_string()
+        }
+        RETURN_CODE_ERROR_INPUT => {
+            "Internal error: the input length of bytes is not correct (0x670A)".to_string()
+        }
+        RETURN_CODE_DECLINE => {
+            "User declined the request on the Ledger device (0x5501)".to_string()
+        }
+        RETURN_CODE_UNKNOWN_ERROR => "Unknown error from the Ledger device (0x5515)".to_string(),
+        _ => format!("Ledger APDU retcode: 0x{:X}", retcode),
+    }
+}
 
 /// Alias of `Vec<u8>`. The goal is naming to help understand what the bytes to deal with
 pub type BorshSerializedUnsignedTransaction<'a> = &'a [u8];
 /// Alias of `Vec<u8>`. The goal is naming to help understand what the bytes to deal with
 pub type BorshSerializedDelegateAction<'a> = &'a [u8];
 
-const P1_GET_PUB_DISPLAY: u8 = 0;
-const P1_GET_PUB_SILENT: u8 = 1;
+pub(crate) const P1_GET_PUB_DISPLAY: u8 = 0;
+pub(crate) const P1_GET_PUB_SILENT: u8 = 1;
 
-const P1_SIGN_NORMAL: u8 = 0;
-const P1_SIGN_NORMAL_LAST_CHUNK: u8 = 0x80;
+pub(crate) const P1_SIGN_NORMAL: u8 = 0;
+pub(crate) const P1_SIGN_NORMAL_LAST_CHUNK: u8 = 0x80;
 
 /// Alias of `Vec<u8>`. The goal is naming to help understand what the bytes to deal with
 pub type NEARLedgerAppVersion = Vec<u8>;
@@ -61,10 +112,13 @@ pub enum NEARLedgerError {
     APDUExchangeError(String),
     /// Error with transport
     LedgerHIDError(LedgerHIDError),
+    /// Error with BLE transport (only available with `ble` feature)
+    #[cfg(feature = "ble")]
+    BleError(String),
 }
 
 /// Converts BIP32Path into bytes (`Vec<u8>`)
-fn hd_path_to_bytes(hd_path: &slipped10::BIP32Path) -> Vec<u8> {
+pub(crate) fn hd_path_to_bytes(hd_path: &slipped10::BIP32Path) -> Vec<u8> {
     (0..hd_path.depth())
         .flat_map(|index| {
             let value = *hd_path.index(index).unwrap();
@@ -74,7 +128,7 @@ fn hd_path_to_bytes(hd_path: &slipped10::BIP32Path) -> Vec<u8> {
 }
 
 #[inline(always)]
-fn log_command(index: usize, is_last_chunk: bool, command: &APDUCommand<Vec<u8>>) {
+pub(crate) fn log_command(index: usize, is_last_chunk: bool, command: &APDUCommand<Vec<u8>>) {
     log::info!(
         "APDU  in{}: {}",
         if is_last_chunk {
@@ -119,10 +173,9 @@ pub fn get_version() -> Result<NEARLedgerAppVersion, NEARLedgerError> {
             if response.retcode() == RETURN_CODE_OK {
                 Ok(response.data().to_vec())
             } else {
-                let retcode = response.retcode();
-
-                let error_string = format!("Ledger APDU retcode: 0x{:X}", retcode);
-                Err(NEARLedgerError::APDUExchangeError(error_string))
+                Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    response.retcode(),
+                )))
             }
         }
         Err(err) => Err(NEARLedgerError::LedgerHIDError(err)),
@@ -133,8 +186,8 @@ fn running_app_name() -> Result<String, NEARLedgerError> {
     let transport = get_transport()?;
 
     let command = APDUCommand {
-        cla: 0xB0,
-        ins: 0x01,
+        cla: CLA_DASHBOARD,
+        ins: INS_GET_APP_NAME,
         p1: 0,
         p2: 0,
         data: vec![],
@@ -169,10 +222,9 @@ fn running_app_name() -> Result<String, NEARLedgerError> {
                     "The ledger most likely is locked. Please unlock ledger or reconnect it"
                         .to_string(),
                 )),
-                retcode => {
-                    let error_string = format!("Ledger APDU retcode: 0x{:X}", retcode);
-                    Err(NEARLedgerError::APDUExchangeError(error_string))
-                }
+                retcode => Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    retcode,
+                ))),
             }
         }
         Err(err) => Err(NEARLedgerError::LedgerHIDError(err)),
@@ -183,8 +235,8 @@ fn quit_open_application() -> Result<(), NEARLedgerError> {
     let transport = get_transport()?;
 
     let command = APDUCommand {
-        cla: 0xB0,
-        ins: 0xa7,
+        cla: CLA_DASHBOARD,
+        ins: INS_QUIT_APP,
         p1: 0,
         p2: 0,
         data: vec![],
@@ -205,10 +257,9 @@ fn quit_open_application() -> Result<(), NEARLedgerError> {
             // we need to check it based on `response.retcode`
             match response.retcode() {
                 RETURN_CODE_OK => Ok(()),
-                retcode => {
-                    let error_string = format!("Ledger APDU retcode: 0x{:X}", retcode);
-                    Err(NEARLedgerError::APDUExchangeError(error_string))
-                }
+                retcode => Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    retcode,
+                ))),
             }
         }
         Err(err) => Err(NEARLedgerError::LedgerHIDError(err)),
@@ -232,10 +283,10 @@ pub fn open_near_application() -> Result<(), NEARLedgerError> {
     }
 
     let transport = get_transport()?;
-    let data = vec![b'N', b'E', b'A', b'R'];
+    let data = b"NEAR".to_vec();
     let command: APDUCommand<Vec<u8>> = APDUCommand {
-        cla: 0xE0,
-        ins: 0xD8,
+        cla: CLA_OPEN_APP,
+        ins: INS_OPEN_APP,
         p1: 0x00,
         p2: 0x00,
         data,
@@ -252,19 +303,9 @@ pub fn open_near_application() -> Result<(), NEARLedgerError> {
             // we need to check it based on `response.retcode`
             match response.retcode() {
                 RETURN_CODE_OK => Ok(()),
-                RETURN_CODE_APP_MISSING => Err(NEARLedgerError::APDUExchangeError(
-                    "NEAR application is missing on the Ledger device".to_string(),
-                )),
-                RETURN_CODE_ERROR_INPUT => Err(NEARLedgerError::APDUExchangeError(
-                    "Internal error: the input length of bytes is not correct".to_string(),
-                )),
-                RETURN_CODE_DECLINE => Err(NEARLedgerError::APDUExchangeError(
-                    "User declined to open the NEAR app".to_string(),
-                )),
-                retcode => {
-                    let error_string = format!("Ledger APDU retcode: 0x{:X}", retcode);
-                    Err(NEARLedgerError::APDUExchangeError(error_string))
-                }
+                retcode => Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                    retcode,
+                ))),
             }
         }
         Err(err) => Err(NEARLedgerError::LedgerHIDError(err)),
@@ -406,10 +447,9 @@ fn handle_public_key_response(
         })?;
         Ok(key)
     } else {
-        let retcode = response.retcode();
-
-        let error_string = format!("Ledger APDU retcode: 0x{:X}", retcode);
-        Err(NEARLedgerError::APDUExchangeError(error_string))
+        Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+            response.retcode(),
+        )))
     }
 }
 
@@ -541,10 +581,9 @@ fn send_payload_apdus(
                         return Ok(response.data().to_vec());
                     }
                 } else {
-                    let retcode = response.retcode();
-
-                    let error_string = format!("Ledger APDU retcode: 0x{:X}", retcode);
-                    return Err(NEARLedgerError::APDUExchangeError(error_string));
+                    return Err(NEARLedgerError::APDUExchangeError(retcode_to_error_string(
+                        response.retcode(),
+                    )));
                 }
             }
             Err(err) => return Err(NEARLedgerError::LedgerHIDError(err)),


### PR DESCRIPTION
<img width="1269" height="989" alt="image" src="https://github.com/user-attachments/assets/b98ed9f3-d294-4dfe-95ba-83d9adf8cc6d" />
First attempt with locked ledger, then fetch version while being in BOLOS and then get public key while being in NEAR app

You may notice that new `ble_api.rs` file has a lot of duplication with `lib.rs`. I thought about making a trait that would unify both hd and ble implementations, but at the end decided that small duplication is not worth of a breaking change. Let me know if it's indeed better to refactor it properly

Resources for review:
- https://developers.ledger.com/docs/device-interaction/references/identifiers
- https://github.com/0xForerunner/ledger-bluetooth/blob/master/ledger-transport-ble/src/lib.rs
- https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/hw-transport-web-ble/src/TransportWebBLE.ts

Related to https://github.com/near/near-cli-rs/issues/569

P.S: Also, `btleplug` lib is async, so I've made ble part here async as well. It doesn't really fit well with sync hd version, but I'm not sure what's the best way to resolve it. And with current approach some workarounds in near-cli-rs would be needed as well