### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/near/near-ledger-rs/compare/v0.9.1...v0.9.2) - 2026-03-11
+
+### Added
+
+- Added optional BLE suport (under `ble` feature flag) ([#30](https://github.com/near/near-ledger-rs/pull/30))
+
+### Other
+
+- Update GitHub Actions token for release-plz workflow
+
 ## [0.9.1](https://github.com/khorolets/near-ledger-rs/compare/v0.9.0...v0.9.1) - 2025-05-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-ledger"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2018"
 authors = ["Bohdan Khorolets <b@khorolets.com>"]
 description = "Transport library to integrate with NEAR Ledger app"


### PR DESCRIPTION



## 🤖 New release

* `near-ledger`: 0.9.1 -> 0.9.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.2](https://github.com/near/near-ledger-rs/compare/v0.9.1...v0.9.2) - 2026-03-11

### Added

- Added optional BLE suport (under `ble` feature flag) ([#30](https://github.com/near/near-ledger-rs/pull/30))

### Other

- Update GitHub Actions token for release-plz workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).