### PR TITLE
chore(deps): replace `slipped10` with `near-slip10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ ed25519-dalek = { version = "2", default-features = false }
 ledger-transport = "0.11.0"
 ledger-transport-hid = "0.11.0"
 ledger-apdu = "0.11.0"
-slipped10 = { version = "0.4.6" }
+near-slip10 = { version = "0.4.7" }
 log = "0.4.20"
 hex = "0.4.3"
 borsh = "1.5"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Provides a set of commands that can be executed to communicate with NEAR App ins
 
 ```rust
 use near_ledger::get_public_key;
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 use std::str::FromStr;
 
 let hd_path = BIP32Path::from_str("44'/397'/0'/0'/1'").unwrap();
@@ -50,7 +50,7 @@ let public_key = near_crypto::PublicKey::ED25519(
 ```rust
 use near_ledger::{sign_transaction, SignTarget};
 use near_primitives::borsh::BorshSerialize;
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 use std::str::FromStr;
 
 let hd_path = BIP32Path::from_str("44'/397'/0'/0'/1'").unwrap();

--- a/examples/common/lib.rs
+++ b/examples/common/lib.rs
@@ -5,7 +5,7 @@ use ed25519_dalek::Signature;
 use ed25519_dalek::Verifier;
 use near_ledger::NEARLedgerError;
 use near_primitives_core::{borsh, borsh::BorshSerialize, hash::CryptoHash, types::AccountId};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 use clap::Parser;
 use near_crypto::SecretKey;

--- a/examples/get_public_key/display.rs
+++ b/examples/get_public_key/display.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use near_ledger::{get_public_key_with_display_flag, NEARLedgerError};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/get_public_key/silent.rs
+++ b/examples/get_public_key/silent.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use near_ledger::{get_public_key_with_display_flag, NEARLedgerError};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/get_public_key_ble.rs
+++ b/examples/get_public_key_ble.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use near_ledger::{get_public_key_ble, open_near_application_ble, NEARLedgerError, TransportBle};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 #[path = "common/lib.rs"]
 mod common;

--- a/examples/get_wallet_id.rs
+++ b/examples/get_wallet_id.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use near_ledger::{get_wallet_id, NEARLedgerError};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 #[path = "./common/lib.rs"]
 mod common;

--- a/examples/sign_nep_366_delegate_action.rs
+++ b/examples/sign_nep_366_delegate_action.rs
@@ -6,7 +6,7 @@ use near_account_id::AccountId;
 use near_crypto::Signature;
 use near_ledger::NEARLedgerError;
 use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 use crate::common::display_pub_key;
 

--- a/examples/sign_nep_366_delegate_action_simple.rs
+++ b/examples/sign_nep_366_delegate_action_simple.rs
@@ -6,7 +6,7 @@ use near_account_id::AccountId;
 use near_crypto::Signature;
 use near_ledger::NEARLedgerError;
 use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 use crate::common::display_pub_key;
 

--- a/examples/sign_nep_413_message.rs
+++ b/examples/sign_nep_413_message.rs
@@ -9,7 +9,7 @@ use ed25519_dalek::Verifier;
 use near_ledger::{NEARLedgerError, NEP413Payload};
 use near_primitives::signable_message::{MessageDiscriminant, SignableMessage};
 use near_primitives_core::{borsh, hash::CryptoHash};
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 
 use crate::common::display_pub_key;
 

--- a/src/ble_api.rs
+++ b/src/ble_api.rs
@@ -183,7 +183,7 @@ pub async fn open_near_application_ble(transport: &TransportBle) -> Result<(), N
 /// The key will be displayed on the Ledger screen for user confirmation.
 pub async fn get_public_key_ble(
     transport: &TransportBle,
-    hd_path: slipped10::BIP32Path,
+    hd_path: near_slip10::BIP32Path,
 ) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
     get_public_key_with_display_flag_ble(transport, hd_path, true).await
 }
@@ -191,7 +191,7 @@ pub async fn get_public_key_ble(
 /// Gets PublicKey from a BLE-connected Ledger, optionally displaying on the device screen
 pub async fn get_public_key_with_display_flag_ble(
     transport: &TransportBle,
-    hd_path: slipped10::BIP32Path,
+    hd_path: near_slip10::BIP32Path,
     display_and_confirm: bool,
 ) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
     let hd_path_bytes = hd_path_to_bytes(&hd_path);
@@ -220,7 +220,7 @@ pub async fn get_public_key_with_display_flag_ble(
 /// Gets the Wallet ID from a BLE-connected Ledger on the given `hd_path`
 pub async fn get_wallet_id_ble(
     transport: &TransportBle,
-    hd_path: slipped10::BIP32Path,
+    hd_path: near_slip10::BIP32Path,
 ) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
     let hd_path_bytes = hd_path_to_bytes(&hd_path);
 
@@ -280,7 +280,7 @@ fn handle_public_key_response_ble(
 pub async fn sign_transaction_ble(
     transport: &TransportBle,
     unsigned_tx: BorshSerializedUnsignedTransaction<'_>,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     send_payload_apdus_ble(
         transport,
@@ -295,7 +295,7 @@ pub async fn sign_transaction_ble(
 pub async fn sign_message_nep413_ble(
     transport: &TransportBle,
     payload: &NEP413Payload,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     send_payload_apdus_ble(
         transport,
@@ -310,7 +310,7 @@ pub async fn sign_message_nep413_ble(
 pub async fn sign_message_nep366_delegate_action_ble(
     transport: &TransportBle,
     payload: BorshSerializedDelegateAction<'_>,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     send_payload_apdus_ble(
         transport,
@@ -324,7 +324,7 @@ pub async fn sign_message_nep366_delegate_action_ble(
 async fn send_payload_apdus_ble(
     transport: &TransportBle,
     payload: &[u8],
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
     ins: u8,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     let hd_path_bytes = hd_path_to_bytes(&seed_phrase_hd_path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub enum NEARLedgerError {
 }
 
 /// Converts BIP32Path into bytes (`Vec<u8>`)
-pub(crate) fn hd_path_to_bytes(hd_path: &slipped10::BIP32Path) -> Vec<u8> {
+pub(crate) fn hd_path_to_bytes(hd_path: &near_slip10::BIP32Path) -> Vec<u8> {
     (0..hd_path.depth())
         .flat_map(|index| {
             let value = *hd_path.index(index).unwrap();
@@ -315,7 +315,7 @@ pub fn open_near_application() -> Result<(), NEARLedgerError> {
 /// Gets PublicKey from the Ledger on the given `hd_path`
 ///
 /// # Inputs
-/// * `hd_path` - seed phrase hd path `slipped10::BIP32Path` for which PublicKey to look
+/// * `hd_path` - seed phrase hd path `near_slip10::BIP32Path` for which PublicKey to look
 ///
 /// # Returns
 ///
@@ -327,7 +327,7 @@ pub fn open_near_application() -> Result<(), NEARLedgerError> {
 ///
 /// ```no_run
 /// use near_ledger::get_public_key;
-/// use slipped10::BIP32Path;
+/// use near_slip10::BIP32Path;
 /// use std::str::FromStr;
 ///
 /// # fn main() {
@@ -351,13 +351,13 @@ pub fn open_near_application() -> Result<(), NEARLedgerError> {
 /// );
 /// ```
 pub fn get_public_key(
-    hd_path: slipped10::BIP32Path,
+    hd_path: near_slip10::BIP32Path,
 ) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
     get_public_key_with_display_flag(hd_path, true)
 }
 
 pub fn get_public_key_with_display_flag(
-    hd_path: slipped10::BIP32Path,
+    hd_path: near_slip10::BIP32Path,
     display_and_confirm: bool,
 ) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
     // instantiate the connection to Ledger
@@ -389,7 +389,7 @@ pub fn get_public_key_with_display_flag(
 }
 
 pub fn get_wallet_id(
-    hd_path: slipped10::BIP32Path,
+    hd_path: near_slip10::BIP32Path,
 ) -> Result<ed25519_dalek::VerifyingKey, NEARLedgerError> {
     // instantiate the connection to Ledger
     // will return an error if Ledger is not connected
@@ -465,7 +465,7 @@ fn get_transport() -> Result<TransportNativeHID, NEARLedgerError> {
 /// # Inputs
 /// * `unsigned_transaction_borsh_serializer` - unsigned transaction `near_primitives::transaction::Transaction`
 ///   which is serialized with `BorshSerializer` and basically is just `Vec<u8>`
-/// * `seed_phrase_hd_path` - seed phrase hd path `slipped10::BIP32Path` with which to sign
+/// * `seed_phrase_hd_path` - seed phrase hd path `near_slip10::BIP32Path` with which to sign
 ///
 /// # Returns
 ///
@@ -477,7 +477,7 @@ fn get_transport() -> Result<TransportNativeHID, NEARLedgerError> {
 /// ```no_run
 /// use near_ledger::sign_transaction;
 /// use near_primitives::{borsh, borsh::BorshSerialize};
-/// use slipped10::BIP32Path;
+/// use near_slip10::BIP32Path;
 /// use std::str::FromStr;
 ///
 /// # fn main() {
@@ -500,7 +500,7 @@ fn get_transport() -> Result<TransportNativeHID, NEARLedgerError> {
 /// ```
 pub fn sign_transaction(
     unsigned_tx: BorshSerializedUnsignedTransaction,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     send_payload_apdus(unsigned_tx, seed_phrase_hd_path, INS_SIGN_TRANSACTION)
 }
@@ -515,7 +515,7 @@ pub struct NEP413Payload {
 
 pub fn sign_message_nep413(
     payload: &NEP413Payload,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     send_payload_apdus(
         &borsh::to_vec(payload).unwrap(),
@@ -526,7 +526,7 @@ pub fn sign_message_nep413(
 
 pub fn sign_message_nep366_delegate_action(
     payload: BorshSerializedDelegateAction,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     send_payload_apdus(
         payload,
@@ -539,7 +539,7 @@ pub fn sign_message_nep366_delegate_action(
 /// as avoiding copy-paste results in re-allocating `payload`
 fn send_payload_apdus(
     payload: &[u8],
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
     ins: u8,
 ) -> Result<SignatureBytes, NEARLedgerError> {
     let transport = get_transport()?;

--- a/src/print_apdus.rs
+++ b/src/print_apdus.rs
@@ -8,7 +8,7 @@ use crate::{
 /// this method is counterpart of [`crate::sign_transaction`]
 pub fn transaction(
     unsigned_tx: crate::BorshSerializedUnsignedTransaction,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) {
     print_payload_apdus(
         unsigned_tx,
@@ -18,7 +18,7 @@ pub fn transaction(
 }
 
 /// this method is counterpart of [`crate::sign_message_nep413`]
-pub fn message_nep413(payload: &crate::NEP413Payload, seed_phrase_hd_path: slipped10::BIP32Path) {
+pub fn message_nep413(payload: &crate::NEP413Payload, seed_phrase_hd_path: near_slip10::BIP32Path) {
     print_payload_apdus(
         &borsh::to_vec(payload).unwrap(),
         seed_phrase_hd_path,
@@ -29,7 +29,7 @@ pub fn message_nep413(payload: &crate::NEP413Payload, seed_phrase_hd_path: slipp
 /// this method is counterpart of [`crate::sign_message_nep366_delegate_action`]
 pub fn nep366_delegate_action(
     payload: crate::BorshSerializedDelegateAction,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) {
     print_payload_apdus(
         payload,
@@ -43,7 +43,7 @@ pub fn nep366_delegate_action(
 /// over it
 pub(crate) fn print_payload_apdus(
     payload: &[u8],
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
     ins: u8,
 ) {
     // seed_phrase_hd_path must be converted into bytes to be sent as `data` to the Ledger


### PR DESCRIPTION
Replaces the unmaintained `slipped10` crate with the `near-slip10` fork (v0.4.7) due to possible supply chain attack. Updates all imports, doc examples, and README snippets accordingly.

Related links:
original slack discussion/report: https://nearone.slack.com/archives/C0A64SAMDNG/p1776266170753839